### PR TITLE
Feature Add flag that limits the results for available versions

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,13 +13,18 @@ const (
 		"tfversion list" +
 		"\n" +
 		"\n" +
+		"# List more available versions\n" +
+		"tfversion list --max-results=20\n" +
+		"\n" +
+		"\n" +
 		"# List all installed Terraform versions\n" +
 		"tfversion list --installed"
 )
 
 var (
-	installed bool
-	listCmd   = &cobra.Command{
+	installed  bool
+	maxResults int
+	listCmd    = &cobra.Command{
 		Use:     "list",
 		Short:   "Lists all Terraform versions",
 		Example: listExample,
@@ -29,10 +34,9 @@ var (
 				for _, version := range installedVersions {
 					fmt.Println(color.BlueString(version))
 				}
-
 			} else {
 				availableVersions := list.GetAvailableVersions()
-				for _, v := range availableVersions {
+				for _, v := range availableVersions[:maxResults] {
 					fmt.Println(color.BlueString(v))
 				}
 			}
@@ -43,4 +47,5 @@ var (
 func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVar(&installed, "installed", false, "list the installed Terraform versions")
+	listCmd.Flags().IntVar(&maxResults, "max-results", 10, "maximum number of versions to list")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,5 +47,5 @@ var (
 func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVar(&installed, "installed", false, "list the installed Terraform versions")
-	listCmd.Flags().IntVar(&maxResults, "max-results", 10, "maximum number of versions to list")
+	listCmd.Flags().IntVar(&maxResults, "max-results", 500, "maximum number of versions to list")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,7 +31,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			if installed {
 				installedVersions := list.GetInstalledVersions()
-				for _, version := range installedVersions {
+				for _, version := range installedVersions[:maxResults] {
 					fmt.Println(color.BlueString(version))
 				}
 			} else {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,12 +31,14 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			if installed {
 				installedVersions := list.GetInstalledVersions()
-				for _, version := range installedVersions[:maxResults] {
+				limit := min(maxResults, len(installedVersions))
+				for _, version := range installedVersions[:limit] {
 					fmt.Println(color.BlueString(version))
 				}
 			} else {
 				availableVersions := list.GetAvailableVersions()
-				for _, v := range availableVersions[:maxResults] {
+				limit := min(maxResults, len(availableVersions))
+				for _, v := range availableVersions[:limit] {
 					fmt.Println(color.BlueString(v))
 				}
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,13 +33,21 @@ var (
 				installedVersions := list.GetInstalledVersions()
 				limit := min(maxResults, len(installedVersions))
 				for _, version := range installedVersions[:limit] {
-					fmt.Println(color.BlueString(version))
+					if list.IsPreReleaseVersion(version) {
+						fmt.Println(color.YellowString(version))
+					} else {
+						fmt.Println(color.BlueString(version))
+					}
 				}
 			} else {
 				availableVersions := list.GetAvailableVersions()
 				limit := min(maxResults, len(availableVersions))
-				for _, v := range availableVersions[:limit] {
-					fmt.Println(color.BlueString(v))
+				for _, version := range availableVersions[:limit] {
+					if list.IsPreReleaseVersion(version) {
+						fmt.Println(color.YellowString(version))
+					} else {
+						fmt.Println(color.BlueString(version))
+					}
 				}
 			}
 		},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,7 +13,7 @@ const (
 		"tfversion list" +
 		"\n" +
 		"\n" +
-		"# List more available versions\n" +
+		"# Limit the number of results\n" +
 		"tfversion list --max-results=20\n" +
 		"\n" +
 		"\n" +


### PR DESCRIPTION
## What
Adds the flag `--max-results=20` to improve console output for `tfversion list`.
Also makes pre-release versions yellow in the list output.

## Why
By default it showed all versions that were ever released, with old ones at the bottom. It's more logical that the user would want to know about the more recent versions instead. Default is set to 500 to keep existing behaviour.
