### PR TITLE
chore: ensure we exit the loop when find the latest version

### DIFF
--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -86,8 +86,9 @@ func FindLatestVersion(preRelease bool) string {
 			continue
 		}
 		foundVersion = v
+		break
 	}
-	if foundVersion == "" {
+	if len(foundVersion) == 0 {
 		fmt.Println("No versions found")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## What
* Make sure to exit the loop when we found the right version

## Why
* `terraform install --latest` broke due to this
