### PR TITLE
Feature: alias command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ tfversion use --latest --pre-release
 tfversion use --required
 ```
 
+### Create and use an alias
+
+```sh
+tfversion alias default 1.7.4
+tfversion use default
+```
+
 ### List versions
 
 ```sh
@@ -90,17 +97,16 @@ tfversion list
 tfversion list --installed
 ```
 
+### List aliased versions
+
+```sh
+tfversion list --aliases
+```
+
 ### Uninstall a specific version
 
 ```sh
 tfversion uninstall 1.7.4
-```
-
-### Create and use an alias
-
-```sh
-tfversion alias default 1.7.4
-tfversion use default
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ tfversion list --installed
 tfversion uninstall 1.7.4
 ```
 
+### Create and use an alias
+
+```sh
+tfversion alias default 1.7.4
+tfversion use default
+```
+
 ## Contributing
 
 Contributions are highly appreciated and always welcome.

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/tfversion/tfversion/pkg/alias"
+)
+
+const (
+	aliasExample = "# Alias a Terraform version\n" +
+		"tfversion alias default 1.7.4"
+)
+
+var (
+	aliasCmd = &cobra.Command{
+		Use:     "alias",
+		Short:   "Alias a Terraform version",
+		Example: aliasExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 2 {
+				fmt.Println("error: provide an alias name and Terraform version")
+				fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion alias -h`"))
+				os.Exit(1)
+			}
+			alias.AliasVersion(args[0], args[1])
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(aliasCmd)
+}

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	aliasExample = "# Alias a Terraform version\n" +
-		"tfversion alias default 1.7.4"
+		"tfversion alias default 1.7.4\n" +
+		"tfversion alias legacy 1.2.4"
 )
 
 var (

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,36 +19,38 @@ const (
 		"\n" +
 		"\n" +
 		"# List all installed Terraform versions\n" +
-		"tfversion list --installed"
+		"tfversion list --installed\n" +
+		"\n" +
+		"\n" +
+		"# List all aliased Terraform versions\n" +
+		"tfversion list --aliased"
 )
 
 var (
 	installed  bool
+	aliases    bool
 	maxResults int
 	listCmd    = &cobra.Command{
 		Use:     "list",
 		Short:   "Lists all Terraform versions",
 		Example: listExample,
 		Run: func(cmd *cobra.Command, args []string) {
+
+			var versions []string
 			if installed {
-				installedVersions := list.GetInstalledVersions()
-				limit := min(maxResults, len(installedVersions))
-				for _, version := range installedVersions[:limit] {
-					if helpers.IsPreReleaseVersion(version) {
-						fmt.Println(color.YellowString(version))
-					} else {
-						fmt.Println(color.CyanString(version))
-					}
-				}
+				versions = list.GetInstalledVersions()
+			} else if aliases {
+				versions = list.GetAliasedVersions()
 			} else {
-				availableVersions := list.GetAvailableVersions()
-				limit := min(maxResults, len(availableVersions))
-				for _, version := range availableVersions[:limit] {
-					if helpers.IsPreReleaseVersion(version) {
-						fmt.Println(color.YellowString(version))
-					} else {
-						fmt.Println(color.CyanString(version))
-					}
+				versions = list.GetAvailableVersions()
+			}
+
+			limit := min(maxResults, len(versions))
+			for _, version := range versions[:limit] {
+				if helpers.IsPreReleaseVersion(version) {
+					fmt.Println(color.YellowString(version))
+				} else {
+					fmt.Println(color.CyanString(version))
 				}
 			}
 		},
@@ -58,5 +60,6 @@ var (
 func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVar(&installed, "installed", false, "list the installed Terraform versions")
+	listCmd.Flags().BoolVar(&aliases, "aliases", false, "list the aliased Terraform versions")
 	listCmd.Flags().IntVar(&maxResults, "max-results", 500, "maximum number of versions to list")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,7 +23,7 @@ const (
 		"\n" +
 		"\n" +
 		"# List all aliased Terraform versions\n" +
-		"tfversion list --aliased"
+		"tfversion list --aliases"
 )
 
 var (

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -1,5 +1,47 @@
 package alias
 
-func AliasVersion(alias string, version string) {
+import (
+	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/fatih/color"
+	"github.com/tfversion/tfversion/pkg/download"
+	"github.com/tfversion/tfversion/pkg/helpers"
+)
+
+func AliasVersion(alias string, version string) {
+	if !download.IsAlreadyDownloaded(version) {
+		if helpers.IsPreReleaseVersion(version) {
+			fmt.Printf("Terraform version %s not found, run %s to install\n", color.YellowString(version), color.CyanString(fmt.Sprintf("`tfversion install %s`", version)))
+		} else {
+			fmt.Printf("Terraform version %s not found, run %s to install\n", color.CyanString(version), color.CyanString(fmt.Sprintf("`tfversion install %s`", version)))
+		}
+		os.Exit(0)
+	}
+
+	// delete existing alias symlink, we consider it non-destructive anyways since you can easily restore it
+	aliasPath := filepath.Join(download.GetDownloadLocation(), alias)
+	_, err := os.Lstat(aliasPath)
+	if err == nil {
+		err = os.RemoveAll(aliasPath)
+		if err != nil {
+			fmt.Printf("error removing symlink: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// create the symlink
+	binaryVersionPath := download.GetInstallLocation(version)
+	err = os.Symlink(binaryVersionPath, aliasPath)
+	if err != nil {
+		fmt.Printf("error creating symlink: %v\n", err)
+		os.Exit(1)
+	}
+
+	if helpers.IsPreReleaseVersion(version) {
+		fmt.Printf("Aliased Terraform version %s as %s\n", color.YellowString(version), color.YellowString(alias))
+	} else {
+		fmt.Printf("Aliased Terraform version %s as %s\n", color.CyanString(version), color.CyanString(alias))
+	}
 }

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tfversion/tfversion/pkg/helpers"
 )
 
+// AliasVersion creates a symlink to the specified Terraform version.
 func AliasVersion(alias string, version string) {
 	if !download.IsAlreadyDownloaded(version) {
 		if helpers.IsPreReleaseVersion(version) {
@@ -48,6 +49,7 @@ func AliasVersion(alias string, version string) {
 	}
 }
 
+// GetAliasLocation returns the directory where tfversion stores the aliases.
 func GetAliasLocation() string {
 	user, err := os.UserHomeDir()
 	if err != nil {
@@ -65,4 +67,19 @@ func GetAliasLocation() string {
 	}
 
 	return aliasLocation
+}
+
+// IsAlias checks if the given alias is valid.
+func IsAlias(alias string) bool {
+	aliasPath := filepath.Join(GetAliasLocation(), alias)
+	_, err := os.Stat(aliasPath)
+	return !os.IsNotExist(err)
+}
+
+// GetVersion returns the Terraform version for the given alias.
+func GetVersion(alias string) string {
+	aliasLocation := GetAliasLocation()
+	resolvePath, _ := filepath.EvalSymlinks(filepath.Join(aliasLocation, alias))
+	_, targetVersion := filepath.Split(resolvePath)
+	return targetVersion
 }

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -20,8 +20,10 @@ func AliasVersion(alias string, version string) {
 		os.Exit(0)
 	}
 
+	aliasLocation := getAliasLocation()
+
 	// delete existing alias symlink, we consider it non-destructive anyways since you can easily restore it
-	aliasPath := filepath.Join(download.GetDownloadLocation(), alias)
+	aliasPath := filepath.Join(aliasLocation, alias)
 	_, err := os.Lstat(aliasPath)
 	if err == nil {
 		err = os.RemoveAll(aliasPath)
@@ -44,4 +46,23 @@ func AliasVersion(alias string, version string) {
 	} else {
 		fmt.Printf("Aliased Terraform version %s as %s\n", color.CyanString(version), color.CyanString(alias))
 	}
+}
+
+func getAliasLocation() string {
+	user, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Printf("error getting user home directory: %s", err)
+		os.Exit(1)
+	}
+
+	aliasLocation := filepath.Join(user, download.ApplicationDir, download.AliasesDir)
+	if _, err := os.Stat(aliasLocation); os.IsNotExist(err) {
+		err := os.Mkdir(aliasLocation, 0755)
+		if err != nil {
+			fmt.Printf("error creating alias directory: %s", err)
+			os.Exit(1)
+		}
+	}
+
+	return aliasLocation
 }

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -20,7 +20,7 @@ func AliasVersion(alias string, version string) {
 		os.Exit(0)
 	}
 
-	aliasLocation := getAliasLocation()
+	aliasLocation := GetAliasLocation()
 
 	// delete existing alias symlink, we consider it non-destructive anyways since you can easily restore it
 	aliasPath := filepath.Join(aliasLocation, alias)
@@ -48,7 +48,7 @@ func AliasVersion(alias string, version string) {
 	}
 }
 
-func getAliasLocation() string {
+func GetAliasLocation() string {
 	user, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Printf("error getting user home directory: %s", err)

--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -1,0 +1,5 @@
+package alias
+
+func AliasVersion(alias string, version string) {
+
+}

--- a/pkg/download/const.go
+++ b/pkg/download/const.go
@@ -7,8 +7,14 @@ const (
 	MaxRetries = 3
 	// RetryTimeInSeconds is the time to wait before retrying a download.
 	RetryTimeInSeconds = 2
-	// DownloadDir is the directory where tfversion downloads Terraform releases.
-	DownloadDir         = ".tfversion"
+	// ApplicationDir is the directory where tfversion downloads Terraform releases.
+	ApplicationDir = ".tfversion"
+	// UseDir is the directory where tfversion puts the symlink to the active version.
+	UseDir = "bin"
+	// VersionsDir is the directory where tfversion installs all versions.
+	VersionsDir = "versions"
+	// AliasesDir is the directory where tfversion stores the aliases.
+	AliasesDir = "aliases"
+	// TerraformBinaryName is the name of the Terraform binary.
 	TerraformBinaryName = "terraform"
-	BinaryDir           = "bin"
 )

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -24,33 +24,34 @@ func GetDownloadLocation() string {
 	user, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Printf("error getting user home directory: %s", err)
+		os.Exit(1)
 	}
-	downloadLocation := filepath.Join(user, DownloadDir)
-	ensureDownloadDirectoryExists(downloadLocation)
-	return downloadLocation
-}
 
-func GetInstallLocation(version string) string {
-	return filepath.Join(GetDownloadLocation(), version)
-}
-
-func GetBinaryLocation(version string) string {
-	return filepath.Join(GetInstallLocation(version), TerraformBinaryName)
-}
-
-func ensureDownloadDirectoryExists(downloadLocation string) {
+	downloadLocation := filepath.Join(user, ApplicationDir, VersionsDir)
 	if _, err := os.Stat(downloadLocation); os.IsNotExist(err) {
 		err := os.Mkdir(downloadLocation, 0755)
 		if err != nil {
 			fmt.Printf("error creating download directory: %s", err)
+			os.Exit(1)
 		}
 	}
+
+	return downloadLocation
+}
+
+// GetInstallLocation returns the directory where a specific Terraform version is installed to.
+func GetInstallLocation(version string) string {
+	return filepath.Join(GetDownloadLocation(), version)
+}
+
+// GetBinaryLocation returns the path to the Terraform binary for the given version.
+func GetBinaryLocation(version string) string {
+	return filepath.Join(GetInstallLocation(version), TerraformBinaryName)
 }
 
 // Download downloads the Terraform release zip file for the given version, OS and architecture.
 func Download(version, goos, goarch string) (string, error) {
 	downloadLocation := GetDownloadLocation()
-	ensureDownloadDirectoryExists(downloadLocation)
 
 	// Construct the download URL based on the version and the OS and architecture.
 	downloadURL := fmt.Sprintf("%s/%s/terraform_%s_%s_%s.zip", TerraformReleasesUrl, version, version, goos, goarch)

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -22,9 +22,7 @@ func GetInstalledVersions() []string {
 
 	var versionNames []string
 	for _, v := range installedVersions {
-		if v.Name() != download.BinaryDir {
-			versionNames = append(versionNames, v.Name())
-		}
+		versionNames = append(versionNames, v.Name())
 	}
 
 	// Check if there are any versions

--- a/pkg/use/use.go
+++ b/pkg/use/use.go
@@ -7,13 +7,24 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/tfversion/tfversion/pkg/alias"
 	"github.com/tfversion/tfversion/pkg/download"
 	"github.com/tfversion/tfversion/pkg/helpers"
 	"github.com/tfversion/tfversion/pkg/list"
 )
 
 // UseVersion activates the specified Terraform version or one of the latest versions
-func UseVersion(version string) {
+func UseVersion(versionOrAlias string) {
+
+	// find the version (via alias or directly)
+	var version string
+	if alias.IsAlias(versionOrAlias) {
+		version = alias.GetVersion(versionOrAlias)
+	} else {
+		version = versionOrAlias
+	}
+
+	// check if the version is installed
 	if !download.IsAlreadyDownloaded(version) {
 		if helpers.IsPreReleaseVersion(version) {
 			fmt.Printf("Terraform version %s not found, run %s to install\n", color.YellowString(version), color.CyanString(fmt.Sprintf("`tfversion install %s`", version)))


### PR DESCRIPTION
## What
Implements alias feature.

```bash
tfversion alias default 1.7.4
tfversion use default
```

## Why
Handy to pin certain versions in your context, for example a client name that is using a specific (legacy) version.

> [!IMPORTANT]  
The directory where versions are installed has changed from `~/.tfversion` to `~/.tfversion/versions`. This is a breaking change and will require either code changes to perform a migration or we need to release this as a breaking change.
