### PR TITLE
Correct subcommand error messages

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -26,7 +26,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {
 				fmt.Println("error: provide a Terraform version to uninstall")
-				fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion install -h`"))
+				fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion uninstall -h`"))
 				os.Exit(1)
 			}
 			uninstall.Uninstall(args[0])

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -42,7 +42,7 @@ var (
 			if latest {
 				if len(args) != 0 {
 					fmt.Println("error: `--latest` flag does not require specifying a Terraform version")
-					fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion install -h`"))
+					fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion use -h`"))
 					os.Exit(1)
 				}
 				use.UseLatestVersion(preRelease)
@@ -53,7 +53,7 @@ var (
 			if required {
 				if len(args) != 0 {
 					fmt.Println("error: `--required` flag does not require specifying a Terraform version")
-					fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion install -h`"))
+					fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion use -h`"))
 					os.Exit(1)
 				}
 				use.UseRequiredVersion()
@@ -63,7 +63,7 @@ var (
 			// use specific version
 			if len(args) != 1 {
 				fmt.Println("error: provide a Terraform version to activate")
-				fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion install -h`"))
+				fmt.Printf("See %s for help and examples\n", color.CyanString("`tfversion use -h`"))
 				os.Exit(1)
 			}
 			use.UseVersion(args[0])


### PR DESCRIPTION
## What
* Corrects error messages for `use` and `uninstall` subcommands.

## Why
To provide the relevant examples and cli usage to users, the error messages should refer to the right subcommands.

## References
* Closes #12 
