### PR TITLE
Ensure download location exists before listing installed terraform versions

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -25,7 +25,9 @@ func GetDownloadLocation() string {
 	if err != nil {
 		fmt.Printf("error getting user home directory: %s", err)
 	}
-	return filepath.Join(user, DownloadDir)
+	downloadLocation := filepath.Join(user, DownloadDir)
+	ensureDownloadDirectoryExists(downloadLocation)
+	return downloadLocation
 }
 
 func GetInstallLocation(version string) string {


### PR DESCRIPTION
## What
Ensures download location exists before listing installed terraform versions.

## Why
To prevent `error listing installation directory` from happening when an user lists installed terraform versions before having downloaded any.

## References
* Closes #11 