### PR TITLE
feat: add flag to optionally list pre-release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ tfversion list --installed
 tfversion list --aliases
 ```
 
+### List pre-release versions
+
+```sh
+tfversion list --pre-release
+```
+
 ### Uninstall a specific version
 
 ```sh

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -26,10 +26,11 @@ const (
 )
 
 var (
-	installed  bool
-	aliases    bool
-	maxResults int
-	listCmd    = &cobra.Command{
+	installed                 bool
+	aliases                   bool
+	maxResults                int
+	includePreReleaseVersions bool
+	listCmd                   = &cobra.Command{
 		Use:     "list",
 		Short:   "Lists all Terraform versions",
 		Example: listExample,
@@ -46,7 +47,11 @@ var (
 
 			limit := min(maxResults, len(versions))
 			for _, version := range versions[:limit] {
-				fmt.Println(helpers.ColoredVersion(version))
+				if helpers.IsPreReleaseVersion(version) && includePreReleaseVersions {
+					fmt.Println(helpers.ColoredVersion(version))
+				} else if !helpers.IsPreReleaseVersion(version) {
+					fmt.Println(helpers.ColoredVersion(version))
+				}
 			}
 		},
 	}
@@ -57,4 +62,5 @@ func init() {
 	listCmd.Flags().BoolVar(&installed, "installed", false, "list the installed Terraform versions")
 	listCmd.Flags().BoolVar(&aliases, "aliases", false, "list the aliased Terraform versions")
 	listCmd.Flags().IntVar(&maxResults, "max-results", 500, "maximum number of versions to list")
+	listCmd.Flags().BoolVarP(&includePreReleaseVersions, "pre-release", "p", false, "include pre-release versions")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,9 +47,7 @@ var (
 
 			limit := min(maxResults, len(versions))
 			for _, version := range versions[:limit] {
-				if helpers.IsPreReleaseVersion(version) && includePreReleaseVersions {
-					fmt.Println(helpers.ColoredVersion(version))
-				} else if !helpers.IsPreReleaseVersion(version) {
+				if !helpers.IsPreReleaseVersion(version) || includePreReleaseVersions {
 					fmt.Println(helpers.ColoredVersion(version))
 				}
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,7 +22,11 @@ const (
 		"\n" +
 		"\n" +
 		"# List all aliased Terraform versions\n" +
-		"tfversion list --aliases"
+		"tfversion list --aliases\n" +
+		"\n" +
+		"\n" +
+		"# Include pre-release versions\n" +
+		"tfversion list --pre-release"
 )
 
 var (

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -60,5 +60,5 @@ func init() {
 	listCmd.Flags().BoolVar(&installed, "installed", false, "list the installed Terraform versions")
 	listCmd.Flags().BoolVar(&aliases, "aliases", false, "list the aliased Terraform versions")
 	listCmd.Flags().IntVar(&maxResults, "max-results", 500, "maximum number of versions to list")
-	listCmd.Flags().BoolVarP(&includePreReleaseVersions, "pre-release", "p", false, "include pre-release versions")
+	listCmd.Flags().BoolVar(&includePreReleaseVersions, "pre-release", false, "include pre-release versions")
 }


### PR DESCRIPTION
## What
* Adds `--pre-release` option to `list` subcommand to display pre-release versions of Terraform
* Changes `list` behavior by hiding pre-release versions by default.

## Why
* Declutters the list of Terraform versions listed, as pre-releases are not relevant for the majority of users.

## References
* Closes #19 
