### PR TITLE
FIx: Use MkdirAll to ensure all parent dirs are also created

### DIFF
--- a/pkg/alias/alias.go
+++ b/pkg/alias/alias.go
@@ -47,7 +47,7 @@ func GetAliasLocation() string {
 
 	aliasLocation := filepath.Join(user, download.ApplicationDir, download.AliasesDir)
 	if _, err := os.Stat(aliasLocation); os.IsNotExist(err) {
-		err := os.Mkdir(aliasLocation, 0755)
+		err := os.MkdirAll(aliasLocation, 0755)
 		if err != nil {
 			helpers.ExitWithError("error creating alias directory", err)
 		}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -27,7 +27,7 @@ func GetDownloadLocation() string {
 
 	downloadLocation := filepath.Join(user, ApplicationDir, VersionsDir)
 	if _, err := os.Stat(downloadLocation); os.IsNotExist(err) {
-		err := os.Mkdir(downloadLocation, 0755)
+		err := os.MkdirAll(downloadLocation, 0755)
 		if err != nil {
 			helpers.ExitWithError("error creating download directory", err)
 		}

--- a/pkg/use/use.go
+++ b/pkg/use/use.go
@@ -104,7 +104,7 @@ func getUseLocation() string {
 
 	useLocation := filepath.Join(user, download.ApplicationDir, download.UseDir)
 	if _, err := os.Stat(useLocation); os.IsNotExist(err) {
-		err := os.Mkdir(useLocation, 0755)
+		err := os.MkdirAll(useLocation, 0755)
 		if err != nil {
 			helpers.ExitWithError("creating use directory", err)
 		}


### PR DESCRIPTION
## What
Fixes an issue when using `install` or `alias` for the first time.

## Why
Fixes a bug
