### PR TITLE
Fix slice bounds out of range error for `tfversion list` 

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,7 +59,7 @@ var (
 			}
 
 			// show the list taking into consideration the max results
-			limit := min(maxResults, len(versions))
+			limit := min(maxResults, len(finalList))
 			for _, version := range finalList[:limit] {
 				fmt.Println(helpers.ColoredVersion(version))
 			}


### PR DESCRIPTION
## What
* Set the right iteration limit

## Why
`tfversion list` would output:
```
panic: runtime error: slice bounds out of range [:309] with capacity 256
```

## References
* N/A
