### PR TITLE
Implement current subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ tfversion list --pre-release
 tfversion uninstall 1.7.4
 ```
 
+### Display the currently activated version of Terraform
+```sh
+tfversion current
+```
+
 ## Contributing
 
 Contributions are highly appreciated and always welcome.

--- a/cmd/current.go
+++ b/cmd/current.go
@@ -1,11 +1,8 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/tfversion/tfversion/pkg/current"
-	"github.com/tfversion/tfversion/pkg/helpers"
 )
 
 const (
@@ -19,11 +16,7 @@ var (
 		Short:   "Print the current active version of Terraform",
 		Example: currentExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := current.CheckCurrentVersion()
-			if err != nil {
-				helpers.ExitWithError("could not determine active Terraform version", err)
-				os.Exit(1)
-			}
+			current.CheckCurrentVersion()
 		},
 	}
 )

--- a/cmd/current.go
+++ b/cmd/current.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/tfversion/tfversion/pkg/current"
+	"github.com/tfversion/tfversion/pkg/helpers"
+)
+
+const (
+	currentExample = "# Print the current active version of Terraform\n" +
+		"tfversion current"
+)
+
+var (
+	currentCmd = &cobra.Command{
+		Use:     "current",
+		Short:   "Print the current active version of Terraform",
+		Example: currentExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := current.CheckCurrentVersion()
+			if err != nil {
+				helpers.ExitWithError("could not determine active Terraform version", err)
+				os.Exit(1)
+			}
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(currentCmd)
+}

--- a/pkg/current/current.go
+++ b/pkg/current/current.go
@@ -1,6 +1,7 @@
 package current
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,17 +13,17 @@ import (
 )
 
 // CheckCurrentVersion prints the current active version of Terraform.
-func CheckCurrentVersion() error {
+func CheckCurrentVersion() {
 
 	symlinkPath := filepath.Join(use.GetUseLocation(), download.TerraformBinaryName)
 	_, err := os.Lstat(symlinkPath)
 	if err != nil {
-		return fmt.Errorf("no active Terraform version found")
+		helpers.ExitWithError("could not determine active Terraform version", err)
 	}
 
 	realPath, err := filepath.EvalSymlinks(symlinkPath)
 	if err != nil {
-		return fmt.Errorf("could not read symlink")
+		helpers.ExitWithError("could not determine active Terraform version", err)
 	}
 	left := fmt.Sprintf("%s/", download.VersionsDir)
 	right := fmt.Sprintf("/%s", download.TerraformBinaryName)
@@ -30,9 +31,8 @@ func CheckCurrentVersion() error {
 	match := rx.FindStringSubmatch(realPath)
 
 	if match == nil {
-		return fmt.Errorf("failed to match regex on path")
+		// helpers.er
+		helpers.ExitWithError("could not determine active Terraform version", errors.New("failed to match regex on path"))
 	}
 	fmt.Printf("Current active Terraform version: %s\n", helpers.ColoredVersion(match[1]))
-
-	return nil
 }

--- a/pkg/current/current.go
+++ b/pkg/current/current.go
@@ -1,11 +1,9 @@
 package current
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"github.com/tfversion/tfversion/pkg/download"
 	"github.com/tfversion/tfversion/pkg/helpers"
@@ -25,14 +23,7 @@ func CheckCurrentVersion() {
 	if err != nil {
 		helpers.ExitWithError("could not determine active Terraform version", err)
 	}
-	left := fmt.Sprintf("%s/", download.VersionsDir)
-	right := fmt.Sprintf("/%s", download.TerraformBinaryName)
-	rx := regexp.MustCompile(`(?s)` + regexp.QuoteMeta(left) + `(.*?)` + regexp.QuoteMeta(right))
-	match := rx.FindStringSubmatch(realPath)
+	_, currentVersion := filepath.Split(filepath.Dir(realPath))
 
-	if match == nil {
-		// helpers.er
-		helpers.ExitWithError("could not determine active Terraform version", errors.New("failed to match regex on path"))
-	}
-	fmt.Printf("Current active Terraform version: %s\n", helpers.ColoredVersion(match[1]))
+	fmt.Printf("Current active Terraform version: %s\n", helpers.ColoredVersion(currentVersion))
 }

--- a/pkg/current/current.go
+++ b/pkg/current/current.go
@@ -1,0 +1,38 @@
+package current
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/tfversion/tfversion/pkg/download"
+	"github.com/tfversion/tfversion/pkg/helpers"
+	"github.com/tfversion/tfversion/pkg/use"
+)
+
+// CheckCurrentVersion prints the current active version of Terraform.
+func CheckCurrentVersion() error {
+
+	symlinkPath := filepath.Join(use.GetUseLocation(), download.TerraformBinaryName)
+	_, err := os.Lstat(symlinkPath)
+	if err != nil {
+		return fmt.Errorf("no active Terraform version found")
+	}
+
+	realPath, err := filepath.EvalSymlinks(symlinkPath)
+	if err != nil {
+		return fmt.Errorf("could not read symlink")
+	}
+	left := fmt.Sprintf("%s/", download.VersionsDir)
+	right := fmt.Sprintf("/%s", download.TerraformBinaryName)
+	rx := regexp.MustCompile(`(?s)` + regexp.QuoteMeta(left) + `(.*?)` + regexp.QuoteMeta(right))
+	match := rx.FindStringSubmatch(realPath)
+
+	if match == nil {
+		return fmt.Errorf("failed to match regex on path")
+	}
+	fmt.Printf("Current active Terraform version: %s\n", helpers.ColoredVersion(match[1]))
+
+	return nil
+}

--- a/pkg/current/current.go
+++ b/pkg/current/current.go
@@ -16,12 +16,12 @@ func CheckCurrentVersion() {
 	symlinkPath := filepath.Join(use.GetUseLocation(), download.TerraformBinaryName)
 	_, err := os.Lstat(symlinkPath)
 	if err != nil {
-		helpers.ExitWithError("could not determine active Terraform version", err)
+		helpers.ExitWithError("no current terraform version found", err)
 	}
 
 	realPath, err := filepath.EvalSymlinks(symlinkPath)
 	if err != nil {
-		helpers.ExitWithError("could not determine active Terraform version", err)
+		helpers.ExitWithError("resolving symlink", err)
 	}
 	_, currentVersion := filepath.Split(filepath.Dir(realPath))
 

--- a/pkg/use/use.go
+++ b/pkg/use/use.go
@@ -30,7 +30,7 @@ func UseVersion(versionOrAlias string) {
 		helpers.ExitWithError("using", err)
 	}
 
-	useLocation := getUseLocation()
+	useLocation := GetUseLocation()
 
 	// inform the user that they need to update their PATH
 	path := os.Getenv("PATH")
@@ -96,7 +96,7 @@ func UseRequiredVersion() {
 	UseVersion(foundVersion)
 }
 
-func getUseLocation() string {
+func GetUseLocation() string {
 	user, err := os.UserHomeDir()
 	if err != nil {
 		helpers.ExitWithError("user home directory", err)


### PR DESCRIPTION
## What
* Implements the `current` subcommand.

```sh
$ tfversion current
Current active Terraform version: 1.7.4
```

## Why
* Nice to have a fast way to check active configuration

## References
* Closes #20

