### PR TITLE
Add API package, rudimentary implemenation

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -53,7 +53,7 @@ var (
 			} else if aliases {
 				versions = list.GetAliasedVersions()
 			} else {
-				versions = list.GetAvailableVersions()
+				versions = list.GetAvailableVersionsFromApi(maxResults)
 			}
 
 			// filter out pre-release versions if needed
@@ -77,6 +77,6 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	listCmd.Flags().BoolVar(&installed, "installed", false, "list the installed Terraform versions")
 	listCmd.Flags().BoolVar(&aliases, "aliases", false, "list the aliased Terraform versions")
-	listCmd.Flags().IntVar(&maxResults, "max-results", 500, "maximum number of versions to list")
+	listCmd.Flags().IntVar(&maxResults, "max-results", 20, "maximum number of versions to list")
 	listCmd.Flags().BoolVar(&includePreReleaseVersions, "pre-release", false, "include pre-release versions")
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/tfversion/tfversion/pkg/download"
+	"github.com/tfversion/tfversion/pkg/helpers"
+)
+
+// TODO: implement automatic pagination depending on maxResults (API returns max. 20 results per page)
+// API docs say to use the timestamp_created of the last list item and use query parameter `after` to get the next page
+
+type Build struct {
+	Arch string `json:"arch"`
+	Os   string `json:"os"`
+	Url  string `json:"url"`
+}
+
+type Status struct {
+	State            string `json:"state"`
+	TimestampUpdated string `json:"timestamp_updated"`
+}
+
+type Release struct {
+	Builds           []Build `json:"builds"`
+	Name             string  `json:"name"`
+	Status           Status  `json:"status"`
+	Version          string  `json:"version"`
+	IsPreRelease     bool    `json:"is_prerelease"`
+	TimestampCreated string  `json:"timestamp_created"`
+	TimestampUpdated string  `json:"timestamp_updated"`
+}
+
+func ListVersions(maxResults int) []string {
+	url := fmt.Sprintf("%s?limit=%v", download.TerraformReleasesApiUrl, maxResults)
+	resp, err := http.Get(url)
+	if err != nil {
+		helpers.ExitWithError("getting Terraform releases from API", err)
+	}
+	defer resp.Body.Close()
+
+	var releases []*Release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		helpers.ExitWithError("getting parsing Terraform releases", err)
+	}
+
+	var availableVersions []string
+	for _, r := range releases {
+		availableVersions = append(availableVersions, r.Version)
+	}
+
+	return availableVersions
+}
+
+func GetVersion(version string) Release {
+	resp, err := http.Get(download.TerraformReleasesApiUrl + "/" + version)
+	if err != nil {
+		helpers.ExitWithError("getting Terraform release from API", err)
+	}
+	defer resp.Body.Close()
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		helpers.ExitWithError("parsing Terraform release", err)
+	}
+
+	return release
+}

--- a/pkg/download/const.go
+++ b/pkg/download/const.go
@@ -3,6 +3,8 @@ package download
 const (
 	// TerraformReleasesUrl is the URL used to download Terraform releases from.
 	TerraformReleasesUrl = "https://releases.hashicorp.com/terraform"
+	// TerraformReleasesApiUrl is the URL to list available Terraform releases.
+	TerraformReleasesApiUrl = "https://api.releases.hashicorp.com/v1/releases/terraform"
 	// MaxRetries is the maximum number of retries for a download.
 	MaxRetries = 3
 	// RetryTimeInSeconds is the time to wait before retrying a download.

--- a/pkg/list/list.go
+++ b/pkg/list/list.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/tfversion/tfversion/pkg/alias"
+	"github.com/tfversion/tfversion/pkg/api"
 	"github.com/tfversion/tfversion/pkg/download"
 	"github.com/tfversion/tfversion/pkg/helpers"
 	"golang.org/x/net/html"
@@ -66,6 +67,10 @@ func GetInstalledVersions() []string {
 	}
 
 	return reversedVersions
+}
+
+func GetAvailableVersionsFromApi(maxResults int) []string {
+	return api.ListVersions(maxResults)
 }
 
 // GetAvailableVersions returns the available Terraform versions from the official Terraform releases page


### PR DESCRIPTION
## What
Use the official releases API instead of scraping a web page.

## Why
Should be more stable and supported, and additional information is available through the API to filter on.

## References
* https://releases.hashicorp.com/docs/api/v1
