### PR TITLE
fix: determine binary name to use during runtime

### DIFF
--- a/pkg/client/zip.go
+++ b/pkg/client/zip.go
@@ -34,7 +34,7 @@ func UnzipRelease(source, destination string) error {
 
 	// Iterate over zip files inside the archive and unzip only the "terraform" binary.
 	for _, f := range reader.File {
-		if f.Name == store.TerraformBinaryName {
+		if f.Name == store.GetTerraformBinaryName() {
 			return unzipFile(f, destination)
 		}
 	}

--- a/pkg/store/const.go
+++ b/pkg/store/const.go
@@ -10,5 +10,5 @@ const (
 	// AliasesDir is the directory where tfversion stores the aliases.
 	AliasesDir = "aliases"
 	// TerraformBinaryName is the name of the Terraform binary.
-	TerraformBinaryName = "terraform"
+	terraformBinaryName = "terraform"
 )

--- a/pkg/store/installed.go
+++ b/pkg/store/installed.go
@@ -31,5 +31,5 @@ func GetInstalledVersionLocation(version string) string {
 
 // GetBinaryLocation returns the path to the Terraform binary for the given version.
 func GetBinaryLocation(version string) string {
-	return filepath.Join(GetInstalledVersionLocation(version), TerraformBinaryName)
+	return filepath.Join(GetInstalledVersionLocation(version), GetTerraformBinaryName())
 }

--- a/pkg/store/use.go
+++ b/pkg/store/use.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"path/filepath"
+	"runtime"
 
 	"tfversion/pkg/helpers"
 )
@@ -18,5 +19,14 @@ func GetUseLocation() string {
 
 // GetActiveBinaryLocation returns the path to the currently active Terraform binary.
 func GetActiveBinaryLocation() string {
-	return filepath.Join(GetUseLocation(), TerraformBinaryName)
+	return filepath.Join(GetUseLocation(), GetTerraformBinaryName())
+}
+
+// GetTerraformBinaryName returns the name of the Terraform binary.
+func GetTerraformBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return terraformBinaryName + ".exe"
+	} else {
+		return terraformBinaryName
+	}
 }


### PR DESCRIPTION
## What
Adds a helper function to return the proper binary name depending on the client OS.

## Why
This is necessary for using tfversion on Windows

## References
Fixes #45 
